### PR TITLE
Add Identity Center account collection to Init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +119,17 @@ name = "async-stream-impl"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1762,6 +1779,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2230,6 +2250,8 @@ dependencies = [
  "mockall_double",
  "regex",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "samuel",
  "serde",
  "serde_json",
@@ -2339,12 +2361,37 @@ checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.11",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2355,7 +2402,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2746,6 +2793,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
@@ -2855,6 +2911,52 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "parking_lot 0.11.2",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3228,7 +3330,7 @@ dependencies = [
  "futures",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.4",
  "scc",
  "serial_test_derive",
 ]
@@ -3336,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.4",
  "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
@@ -4051,6 +4153,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,7 +4214,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.5.12",
  "wasite",
  "web-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ aws-smithy-types = "1"
 aws-runtime = "1"
 aws-types = "1"
 mockall_double = "0.3"
+reqwest-retry = "0.7.0"
+reqwest-middleware = "0.4.2"
 
 [dev-dependencies]
 aws-smithy-runtime = { version = "1", features = ["test-util"] }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -3,17 +3,15 @@ use mockall_double::double;
 #[double]
 use crate::okta::client::Client as OktaClient;
 use crate::{
-    aws::saml::extract_account_name,
-    aws::sso::Client as SsoClient,
-    aws::{get_account_alias, sts_client},
-    okta::applications::AppLink,
+    aws::{sso::Client as SsoClient, sts_client},
+    okta::applications::{AppLink, AppLinkAccountRoleMapping, IntegrationType},
     select,
 };
 
 use aws_credential_types::Credentials;
 use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
-use tracing::{instrument, trace, warn};
+use tracing::{instrument, trace};
 
 /// This is an intentionally 'loose' struct,
 /// representing the potential various ways of providing a profile.
@@ -30,72 +28,66 @@ pub enum Config {
 }
 
 impl Config {
-    #[instrument(skip(client, link, default_role), fields(organization=%client.base_url(), application=%link.label))]
-    pub async fn from_app_link(
-        client: &OktaClient,
-        link: AppLink,
-        default_role: Option<String>,
+    pub async fn from_account_mapping(
+        mapping: AppLinkAccountRoleMapping,
+        default_roles: Option<Vec<String>>,
     ) -> Result<(String, Self)> {
-        let response = client.get_saml_response(link.link_url).await?;
-        let aws_response = match response.clone().post().await {
-            Err(e) => {
-                warn!("Caught error trying to login to AWS: {}, trying again", e);
-                response.clone().post().await
+        let default_roles_available = if let Some(default_roles) = default_roles {
+            mapping
+                .role_names
+                .clone()
+                .into_iter()
+                .filter(|name| default_roles.contains(name))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        let role_name = match mapping.role_names.len() {
+            0 => Err(eyre!(
+                "No profiles found for application {}",
+                mapping.account_name
+            )),
+            1 => Ok(mapping.role_names.first().unwrap().to_string()),
+            _ if default_roles_available.len() == 1 => {
+                Ok(default_roles_available.first().unwrap().to_string())
             }
-            ok => ok,
+            _ if default_roles_available.len() > 1 => Ok(select(
+                default_roles_available.clone(),
+                format!("Choose Role for {}", mapping.account_name),
+                |name| name.clone(),
+            )?),
+            _ => Ok(select(
+                mapping.role_names.clone(),
+                format!("Choose Role for {}", mapping.account_name),
+                |name| name.clone(),
+            )?),
         }?;
-        let aws_response_text = aws_response.text().await?;
-
-        let roles = response.clone().roles()?;
-
-        let saml_role = match roles.len() {
-            0 => Err(eyre!("No role found")),
-            1 => Ok(roles.first().unwrap()),
-            _ => {
-                if let Some(default_role) = default_role.clone() {
-                    match roles
-                        .iter()
-                        .find(|role| role.role_name().unwrap() == default_role)
-                    {
-                        Some(role) => Ok(role),
-                        None => select(
-                            roles.iter().collect(),
-                            format!("Choose Role for {}", link.label),
-                            |role| role.role.clone(),
-                        ),
-                    }
-                } else {
-                    select(
-                        roles.iter().collect(),
-                        format!("Choose Role for {}", link.label),
-                        |role| role.role.clone(),
-                    )
-                }
+        let profile_config = if default_roles_available.contains(&role_name)
+            && default_roles_available.len() == 1
+            && mapping.integration_type == IntegrationType::Federated
+        {
+            Self::Name(mapping.application_name)
+        } else if default_roles_available.contains(&role_name)
+            && default_roles_available.len() == 1
+            && mapping.integration_type == IntegrationType::IdentityCenter
+        {
+            Self::Detailed {
+                application: mapping.application_name.clone(),
+                account: Some(mapping.account_name.clone()),
+                role: None,
+                duration_seconds: None,
             }
-        }?;
-
-        let role_name = saml_role.role_name()?.to_string();
-
-        let account_name = get_account_alias(saml_role, &response)
-            .await
-            .or_else(|_| extract_account_name(&aws_response_text))
-            .unwrap_or_else(|_| {
-                warn!("No AWS account alias found. Falling back on Okta Application name");
-                link.label.clone()
-            });
-
-        let profile_config = if Some(role_name.clone()) == default_role {
-            Self::Name(link.label)
         } else {
             Self::Detailed {
-                application: link.label,
-                account: None,
+                application: mapping.application_name.clone(),
+                account: Some(mapping.account_name.clone()),
                 role: Some(role_name),
                 duration_seconds: None,
             }
         };
 
-        Ok((account_name, profile_config))
+        Ok((mapping.account_name.clone(), profile_config))
     }
 }
 
@@ -106,7 +98,7 @@ pub struct Profile {
     pub name: String,
     pub application_name: String,
     pub account: Option<String>,
-    pub role: String,
+    pub role: Vec<String>,
     pub duration_seconds: Option<i32>,
 }
 
@@ -119,7 +111,7 @@ impl Profile {
     pub fn try_from_spec(
         profile_config: &Config,
         name: String,
-        default_role: Option<String>,
+        default_roles: Option<Vec<String>>,
         default_duration_seconds: Option<i32>,
     ) -> Result<Self> {
         Ok(Self {
@@ -135,9 +127,9 @@ impl Profile {
             },
             role: match profile_config {
                 Config::Name(_) => None,
-                Config::Detailed { role, .. } => role.clone(),
+                Config::Detailed { role, .. } => role.clone().map(|r| vec![r]),
             }
-            .or(default_role)
+            .or(default_roles)
             .ok_or_else(|| eyre!("No role found"))?,
             duration_seconds: match profile_config {
                 Config::Name(_) => None,
@@ -189,17 +181,27 @@ impl Profile {
                 )
             })?;
 
-        let saml_role = response
+        let saml_roles_available = response
             .roles()?
             .into_iter()
-            .find(|r| r.role_name().map(|r| r == self.role).unwrap_or(false))
-            .ok_or_else(|| {
-                eyre!(
-                    "No matching role ({}) found for profile {}",
-                    self.role,
-                    &self.name
-                )
-            })?;
+            .filter(|r| self.role.contains(&r.role_name().unwrap()))
+            .collect::<Vec<_>>();
+
+        let saml_role = match saml_roles_available.len() {
+            0 => Err(eyre!(
+                "No roles found for profile {} in SAML response",
+                self.name
+            )),
+            1 => Ok(saml_roles_available[0].clone()),
+            _ => {
+                let selected = select(
+                    saml_roles_available,
+                    format!("Choose Role for profile {}", self.name),
+                    |role| role.role_name().unwrap().to_string(),
+                )?;
+                Ok(selected)
+            }
+        }?;
 
         trace!("Found role: {} for profile {}", saml_role.role, &self.name);
 
@@ -218,38 +220,11 @@ impl Profile {
         client: &OktaClient,
         app_link: AppLink,
     ) -> Result<Credentials> {
-        let response = client
-            .get_saml_response(app_link.link_url)
-            .await
-            .map_err(|e| {
-                eyre!(
-                    "Error getting SAML response for profile {} ({})",
-                    self.name,
-                    e
-                )
-            })?;
+        let org_auth = client
+            .get_org_id_and_auth_code_for_app_link(app_link)
+            .await?;
 
-        let response = response.post().await?;
-        let host = response
-            .url()
-            .host()
-            .ok_or_else(|| eyre!("No host found"))?;
-        let org_id = if let url::Host::Domain(domain) = host {
-            domain
-                .split_once('.')
-                .map(|(org, _)| org)
-                .ok_or_else(|| eyre!("No dots found in domain: {:?}", domain))
-        } else {
-            Err(eyre!("Host: {:?} is not a domain", host))
-        }?;
-        let auth_code = response
-            .url()
-            .query_pairs()
-            .find(|(k, _)| k.eq("workflowResultHandle"))
-            .ok_or_else(|| eyre!("No token found"))?
-            .1;
-
-        let client = SsoClient::new(org_id, &auth_code).await?;
+        let client = SsoClient::new(&org_auth.org_id, &org_auth.auth_code).await?;
 
         let app_instance = if let Some(account) = self.account {
             client
@@ -267,12 +242,29 @@ impl Profile {
             .account_id()
             .ok_or_else(|| eyre!("No account ID found"))?;
 
-        let profile = client
+        let profiles_available = client
             .profiles(&app_instance.id)
             .await?
             .into_iter()
-            .find(|profile| profile.name == self.role)
-            .ok_or_else(|| eyre!("Cound not find profile: {}", self.role))?;
+            .filter(|profile| self.role.contains(&profile.name))
+            .collect::<Vec<_>>();
+
+        let profile = match profiles_available.len() {
+            0 => Err(eyre!(
+                "No profiles found for application {}",
+                app_instance.name
+            )),
+            1 => Ok(profiles_available[0].clone()),
+            _ => {
+                let selected = select(
+                    profiles_available,
+                    format!("Choose Profile for application {}", app_instance.name),
+                    |profile| profile.name.clone(),
+                )?;
+                Ok(selected)
+            }
+        }?;
+
         trace!("Found profile: {:?}", profile);
 
         let credentials = client.credentials(account_id, &profile.name).await?;

--- a/src/okta/applications.rs
+++ b/src/okta/applications.rs
@@ -1,9 +1,15 @@
-use crate::{aws::role::SamlRole, okta::client::Client};
+use crate::{
+    aws::{get_account_alias, saml::extract_account_name},
+    okta::client::Client,
+};
 
-use eyre::Result;
+use eyre::{eyre, Result};
 use futures::future::join_all;
 use serde::Deserialize;
+use tracing::warn;
 use url::Url;
+
+use crate::aws::sso::{AppInstance, Client as SsoClient};
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -13,7 +19,72 @@ pub struct AppLink {
     pub app_name: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IntegrationType {
+    Federated,
+    IdentityCenter,
+}
+
+#[derive(Clone, Debug)]
+pub struct AppLinkAccountRoleMapping {
+    pub account_name: String,
+    pub role_names: Vec<String>,
+    pub application_name: String,
+    pub integration_type: IntegrationType,
+}
+
+pub struct SsoOrgAuth {
+    pub org_id: String,
+    pub auth_code: String,
+}
+
 impl Client {
+    /// Given an `AppLink`, return the org Id and auth code needed to create an SSO client
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there are any errors while fetching the roles.
+    pub async fn get_org_id_and_auth_code_for_app_link(
+        &self,
+        app_link: AppLink,
+    ) -> Result<SsoOrgAuth> {
+        let response = self
+            .get_saml_response(app_link.link_url)
+            .await
+            .map_err(|e| {
+                eyre!(
+                    "Error getting SAML response for app link {} ({})",
+                    app_link.label,
+                    e
+                )
+            })?;
+
+        let response = response.post().await?;
+        let host = response
+            .url()
+            .host()
+            .ok_or_else(|| eyre!("No host found"))?;
+        let org_id = if let url::Host::Domain(domain) = host {
+            domain
+                .split_once('.')
+                .map(|(org, _)| org)
+                .ok_or_else(|| eyre!("No dots found in domain: {:?}", domain))
+        } else {
+            Err(eyre!("Host: {:?} is not a domain", host))
+        }?;
+        let auth_code = response
+            .url()
+            .query_pairs()
+            .find(|(k, _)| k.eq("workflowResultHandle"))
+            .ok_or_else(|| eyre!("No token found"))?
+            .1;
+
+        Ok(SsoOrgAuth {
+            org_id: (org_id.to_string()),
+            auth_code: (auth_code.to_string()),
+        })
+    }
+
     /// Return all the `AppLink`s for a given user.
     /// If `user_id` is None, assume the current user.
     ///
@@ -28,27 +99,166 @@ impl Client {
         .await
     }
 
-    /// Given an `AppLink`, visit it to get the AWS roles that can be assumed
+    /// Given an amazon_aws federated `AppLink`, visit it to get the account name and roles that can be assumed
     ///
     /// # Errors
     ///
     /// Will return `Err` if there are any errors while fetching the roles.
-    pub async fn roles(&self, link: AppLink) -> Result<Vec<SamlRole>> {
-        self.get_saml_response(link.link_url).await?.roles()
+    pub async fn get_saml_account_role_mapping(
+        &self,
+        link: AppLink,
+    ) -> Result<AppLinkAccountRoleMapping> {
+        let response = self.get_saml_response(link.link_url).await?;
+        let aws_response = match response.clone().post().await {
+            Err(e) => {
+                warn!("Caught error trying to login to AWS: {}, trying again", e);
+                response.clone().post().await
+            }
+            ok => ok,
+        }?;
+
+        let aws_response_text = aws_response.text().await?;
+        let roles = response.clone().roles()?;
+
+        if roles.is_empty() {
+            return Err(eyre!("No roles found for app link: {}", link.label));
+        }
+
+        let role_names = roles
+            .clone()
+            .into_iter()
+            .map(|role| role.role_name().unwrap().to_string())
+            .collect::<Vec<_>>();
+
+        let account_name = get_account_alias(&roles[0].clone(), &response)
+            .await
+            .or_else(|_| extract_account_name(&aws_response_text))
+            .unwrap_or_else(|_| {
+                warn!("No AWS account alias found. Falling back on Okta Application name");
+                link.label.clone()
+            });
+
+        let application_name = link.label.clone();
+
+        Ok(AppLinkAccountRoleMapping {
+            account_name,
+            role_names,
+            application_name,
+            integration_type: IntegrationType::Federated,
+        })
     }
 
-    /// Given a list of `AppLink`s, visit each of them to get the AWS roles that can be assumed
+    /// Given an amazon_aws_sso identity center `AppInstance`, visit it to get the account name and roles that can be assumed
     ///
     /// # Errors
     ///
     /// Will return `Err` if there are any errors while fetching the roles.
-    pub async fn all_roles(&self, links: Vec<AppLink>) -> Result<Vec<SamlRole>> {
-        let role_futures = links.into_iter().map(|link| self.roles(link));
-        let roles = join_all(role_futures)
+    async fn get_sso_account_role_mapping(
+        &self,
+        app_instance: &AppInstance,
+        application_name: String,
+        sso_client: &SsoClient,
+    ) -> Result<AppLinkAccountRoleMapping> {
+        let profiles = sso_client.profiles(&app_instance.id).await?;
+
+        if profiles.is_empty() {
+            return Err(eyre!(
+                "No roles found for app instance: {}",
+                app_instance.name
+            ));
+        }
+
+        let role_names = profiles.iter().map(|p| p.name.clone()).collect::<Vec<_>>();
+        let account_name = app_instance
+            .account_name()
+            .ok_or_else(|| {
+                eyre!(
+                    "No account name found for app instance: {}",
+                    app_instance.name
+                )
+            })?
+            .to_string();
+
+        Ok(AppLinkAccountRoleMapping {
+            account_name,
+            role_names,
+            application_name,
+            integration_type: IntegrationType::IdentityCenter,
+        })
+    }
+
+    /// Given an amazon_aws_sso identity center `AppLink`, iterate through all app instances to get a list of all account names and roles that can be assumed
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there are any errors while fetching the roles.
+    pub async fn get_sso_applink_accounts_and_roles(
+        &self,
+        app_link: AppLink,
+    ) -> Result<Vec<AppLinkAccountRoleMapping>> {
+        let app_name = app_link.clone().label;
+        let org_auth = self.get_org_id_and_auth_code_for_app_link(app_link).await?;
+        let sso_client = SsoClient::new(&org_auth.org_id, &org_auth.auth_code).await?;
+
+        let app_instances = sso_client.app_instances().await?;
+
+        let mut all_account_role_mappings = Vec::new();
+        let batch_size = 5;
+        for chunk in app_instances.chunks(batch_size) {
+            let mut futures = Vec::new();
+            for app_instance in chunk {
+                futures.push(self.get_sso_account_role_mapping(
+                    app_instance,
+                    app_name.clone(),
+                    &sso_client,
+                ));
+            }
+            let nested_account_role_mappings = futures::future::join_all(futures).await;
+            let account_role_mappings = nested_account_role_mappings
+                .into_iter()
+                .collect::<Result<Vec<AppLinkAccountRoleMapping>>>()?;
+            all_account_role_mappings.extend(account_role_mappings);
+        }
+        Ok(all_account_role_mappings)
+    }
+
+    /// Given a list of `AppLink`s, visit each of them to get a list of all account names and roles that can be assumed
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there are any errors while fetching the roles.
+    pub async fn get_all_account_mappings(
+        &self,
+        links: Vec<AppLink>,
+    ) -> Result<Vec<AppLinkAccountRoleMapping>> {
+        let mut saml_role_futures = Vec::new();
+        let mut all_role_names = Vec::new(); // We don't want to run sso app links concurrently due to rate limiting
+        for link in links {
+            if link.app_name == "amazon_aws" {
+                saml_role_futures.push(self.get_saml_account_role_mapping(link));
+            } else if link.app_name == "amazon_aws_sso" {
+                all_role_names.extend(self.get_sso_applink_accounts_and_roles(link).await?);
+            } else {
+                return Err(eyre!("Unsupported app name: {}", link.app_name));
+            }
+        }
+        let saml_roles = join_all(saml_role_futures)
             .await
             .into_iter()
-            .collect::<Result<Vec<Vec<SamlRole>>, _>>()?;
+            .collect::<Result<Vec<AppLinkAccountRoleMapping>>>()?;
 
-        Ok(roles.into_iter().flatten().collect())
+        Ok(vec![all_role_names, saml_roles].concat())
+    }
+
+    /// Given an identity center `AppLink`, return all app instances
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there are any errors while fetching the roles.
+    pub async fn all_app_instances(&self, app_link: AppLink) -> Result<Vec<AppInstance>> {
+        let org_auth = self.get_org_id_and_auth_code_for_app_link(app_link).await?;
+        let sso_client = SsoClient::new(&org_auth.org_id, &org_auth.auth_code).await?;
+
+        Ok(sso_client.app_instances().await?)
     }
 }

--- a/src/okta/client.rs
+++ b/src/okta/client.rs
@@ -286,7 +286,9 @@ mockall::mock! {
     pub Client {
         pub fn base_url(&self) -> &Url;
         pub async fn app_links(&self, user_id: Option<()>) -> Result<Vec<crate::okta::applications::AppLink>>;
-        pub async fn all_roles(&self, links: Vec<crate::okta::applications::AppLink>) -> Result<Vec<crate::aws::role::SamlRole>>;
+        pub async fn get_all_account_mappings(&self, links: Vec<crate::okta::applications::AppLink>) -> Result<Vec<crate::okta::applications::AppLinkAccountRoleMapping>>;
         pub async fn get_saml_response(&self, url: Url) -> Result<crate::aws::saml::Response>;
+        pub async fn get_response(&self, url: Url) -> Result<Response>;
+        pub async fn get_org_id_and_auth_code_for_app_link(&self, app_link: crate::okta::applications::AppLink) -> Result<crate::okta::applications::SsoOrgAuth>;
     }
 }


### PR DESCRIPTION
Add logic to gather identity center sso account profiles during init as well as federated account apps, only iterate over app links once to make requests, add retry logic to portal-sso api calls.


This has been tested locally with successful runs of init and refresh commands.