### PR TITLE
Role Override feature

### DIFF
--- a/src/config/organization.rs
+++ b/src/config/organization.rs
@@ -201,9 +201,13 @@ impl Organization {
         self,
         client: &OktaClient,
         filter: glob::Pattern,
+        role_override: Option<&String>,
     ) -> impl Iterator<Item = (String, Credentials)> {
         let futures = self.into_profiles(filter).map(|profile| async {
-            (profile.name.clone(), profile.into_credentials(client).await)
+            (
+                profile.name.clone(),
+                profile.into_credentials(client, role_override).await,
+            )
         });
 
         stream::iter(futures)

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ struct RefreshArgs {
     #[clap(default_value = "*")]
     pub profiles: Pattern,
 
+    /// Role to override toml file with
+    #[clap(short, long = "role-override")]
+    pub role_override: Option<String>,
+
     /// Forces new credentials
     #[clap(short, long = "force-new")]
     pub force_new: bool,
@@ -101,7 +105,11 @@ async fn refresh(args: RefreshArgs) -> Result<()> {
         .await?;
 
         let credentials_map = organization
-            .into_credentials(&okta_client, args.profiles.clone())
+            .into_credentials(
+                &okta_client,
+                args.profiles.clone(),
+                args.role_override.as_ref(),
+            )
             .await;
 
         for (name, creds) in credentials_map {


### PR DESCRIPTION
Adding feature to specify a role override during refresh to get credentials.

This will override any roles specified in the org toml file but will not write to the toml file so that your configuration will go back to the original roles in future runs.

If role override is specified, any account that does not have that role will throw an error similar to if there were no roles in the account to begin with.

Tested locally against saml and sso profiles.