### PR TITLE
Migrate to Rust 2024 and align formatters

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest     # x86_64-linux
-          - macos-15-intel    # x86_64-darwin
           - macos-latest      # aarch64-darwin
           - ubuntu-24.04-arm  # aarch64-linux
     runs-on: ${{ matrix.runner }}
@@ -35,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
-        if: matrix.runner != 'macos-15-intel'
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ tokio-test = "0.4"
 [package]
 authors = ["Jonathan Morley <morley.jonathan@gmail.com>"]
 description = "Generates temporary AWS credentials with Okta."
-edition = "2021"
+edition = "2024"
 name = "oktaws"
 version = "0.23.0"
 license = "Apache-2.0"

--- a/docs/superpowers/plans/2026-07-14-rust-2024-formatting.md
+++ b/docs/superpowers/plans/2026-07-14-rust-2024-formatting.md
@@ -1,0 +1,152 @@
+# Rust 2024 Formatting Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate oktaws to Rust edition 2024 and guarantee that `cargo fmt` and `nix fmt` use the same manifest-declared edition.
+
+**Architecture:** `Cargo.toml` remains the authoritative crate metadata. The treefmt-nix rustfmt integration reads the package edition from that manifest instead of relying on treefmt-nix's default, so both formatter entry points pass edition 2024 to the same rustfmt behavior.
+
+**Tech Stack:** Rust 2024, Cargo, rustfmt 1.9.0, Nix flakes, treefmt-nix
+
+## Global Constraints
+
+- Set the crate edition to exactly `2024`.
+- Read treefmt's rustfmt edition from `Cargo.toml`; do not duplicate the edition string in `treefmt.nix`.
+- Limit source changes to compiler-required edition migration edits and rustfmt output.
+- Add no dependency and perform no unrelated refactor.
+- Use formatter convergence plus the existing check, test, clippy, and Nix flake checks as regression coverage; do not add a unit test for configuration-only behavior.
+
+______________________________________________________________________
+
+## File Structure
+
+- Modify `Cargo.toml`: declare Rust edition 2024 as the single source of truth.
+- Modify `treefmt.nix`: pass the manifest edition to treefmt-nix's rustfmt module.
+- Modify `src/**/*.rs` only if `cargo fix --edition` or edition-2024 rustfmt requires changes.
+- Create no production or test files.
+
+### Task 1: Migrate to Rust 2024 and converge the formatters
+
+**Files:**
+
+- Modify: `Cargo.toml:63-73`
+- Modify: `treefmt.nix:15-21`
+- Modify if required: `src/**/*.rs`
+- Test: existing Rust test targets and formatter checks
+
+**Interfaces:**
+
+- Consumes: `Cargo.toml` package metadata and treefmt-nix's `programs.rustfmt.edition` option.
+
+- Produces: a Rust 2024 crate for which Cargo and treefmt invoke rustfmt with the same edition.
+
+- [ ] **Step 1: Re-run the failing formatter regression check**
+
+Run:
+
+```bash
+nix develop -c cargo fmt --all -- --check
+```
+
+Expected: FAIL with edition-sensitive diffs such as `eyre::{Result, eyre}` becoming `eyre::{eyre, Result}`. This proves the committed edition-2024 treefmt output still disagrees with Cargo while the manifest says edition 2021.
+
+- [ ] **Step 2: Apply Cargo's edition compatibility migration**
+
+Run while `Cargo.toml` still declares edition 2021:
+
+```bash
+nix develop -c cargo fix --edition --all-targets --all-features
+```
+
+Expected: exit 0. Cargo applies any compiler-suggested edition-2024 compatibility rewrites without changing the manifest edition.
+
+Review any changed Rust files immediately:
+
+```bash
+git diff -- src
+```
+
+Expected: only compiler-suggested compatibility changes, or no diff when the existing code is already edition-2024 compatible.
+
+- [ ] **Step 3: Change the manifest edition and connect treefmt to it**
+
+Apply this patch:
+
+```diff
+*** Begin Patch
+*** Update File: Cargo.toml
+@@
+-edition = "2021"
++edition = "2024"
+*** Update File: treefmt.nix
+@@
+-      programs.rustfmt.enable = true; # rust
++      programs.rustfmt = {
++        enable = true; # rust
++        edition =
++          (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.edition;
++      };
+*** End Patch
+```
+
+Expected: the crate and treefmt both obtain edition `2024` from `Cargo.toml`.
+
+- [ ] **Step 4: Apply canonical formatting once**
+
+Run:
+
+```bash
+nix develop -c cargo fmt --all
+nix fmt
+```
+
+Expected: both commands succeed. The first applies Rust 2024 formatting; the second formats every configured repository file and makes no opposing Rust edits.
+
+- [ ] **Step 5: Verify formatter convergence**
+
+Run:
+
+```bash
+nix develop -c cargo fmt --all -- --check
+nix fmt -- --fail-on-change
+nix develop -c cargo fmt --all -- --check
+```
+
+Expected: all three commands exit 0; treefmt reports zero changed files, and both Cargo checks are clean.
+
+- [ ] **Step 6: Run the Rust and Nix verification suite**
+
+Run:
+
+```bash
+nix develop -c cargo check --all-targets --all-features
+nix develop -c cargo test --all-targets --all-features
+nix develop -c cargo clippy --all-targets --all-features -- -D warnings
+nix flake check --print-build-logs --no-update-lock-file
+```
+
+Expected: every command exits 0. Tests pass, clippy emits no warnings, and the flake's clippy, nextest, and treefmt checks succeed.
+
+- [ ] **Step 7: Review the completed migration**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat
+git diff -- Cargo.toml treefmt.nix src
+git status --short
+```
+
+Expected: no whitespace errors; the diff contains only the manifest edition, the treefmt edition linkage, compiler-required compatibility edits, and Rust 2024 formatting.
+
+- [ ] **Step 8: Commit the implementation**
+
+Stage only the reviewed migration files, including any Rust files actually changed:
+
+```bash
+git add Cargo.toml treefmt.nix src
+git commit -m "build: migrate to Rust 2024 edition"
+```
+
+Expected: one focused implementation commit after the separate design and plan commits.

--- a/docs/superpowers/plans/2026-07-14-rust-2024-formatting.md
+++ b/docs/superpowers/plans/2026-07-14-rust-2024-formatting.md
@@ -15,6 +15,8 @@
 - Limit source changes to compiler-required edition migration edits and rustfmt output.
 - Add no dependency and perform no unrelated refactor.
 - Use formatter convergence plus the existing check, test, clippy, and Nix flake checks as regression coverage; do not add a unit test for configuration-only behavior.
+- Drop only Nix support for `x86_64-darwin`; retain the Intel macOS binary release target.
+- Include the narrow Rust 1.97 Clippy fixes discovered by the PR checks.
 
 ______________________________________________________________________
 
@@ -23,6 +25,8 @@ ______________________________________________________________________
 - Modify `Cargo.toml`: declare Rust edition 2024 as the single source of truth.
 - Modify `treefmt.nix`: pass the manifest edition to treefmt-nix's rustfmt module.
 - Modify `src/**/*.rs` only if `cargo fix --edition` or edition-2024 rustfmt requires changes.
+- Modify `flake.nix` and `.github/workflows/pull.yml`: remove the unsupported `x86_64-darwin` Nix output and runner.
+- Modify `src/aws/profile.rs` and `src/main.rs`: remove the redundant formatting-argument borrows rejected by Rust 1.97 Clippy.
 - Create no production or test files.
 
 ### Task 1: Migrate to Rust 2024 and converge the formatters
@@ -150,3 +154,9 @@ git commit -m "build: migrate to Rust 2024 edition"
 ```
 
 Expected: one focused implementation commit after the separate design and plan commits.
+
+### Task 2: Repair the pre-existing cross-platform CI failures
+
+The locked Nixpkgs 26.11 revision no longer supports `x86_64-darwin`. Remove that system from `flake.nix` and remove the corresponding `macos-15-intel` Nix job from the pull-request workflow. Keep `x86_64-apple-darwin` in `dist-workspace.toml`, because Intel macOS binary releases remain supported independently of Nix.
+
+Remove the redundant borrows from `path.display()` in `src/aws/profile.rs` and `org_toml` in `src/main.rs` so Rust 1.97 Clippy passes on Windows. Verify formatter convergence, Clippy, all 118 tests, native `nix flake check`, and evaluation of every remaining flake system.

--- a/docs/superpowers/specs/2026-07-14-rust-2024-formatting-design.md
+++ b/docs/superpowers/specs/2026-07-14-rust-2024-formatting-design.md
@@ -25,10 +25,10 @@ If `cargo fix --edition` reports code that cannot be migrated automatically, han
 This configuration/toolchain migration does not add a unit test. Its regression proof is formatter convergence and the existing behavioral suite:
 
 1. Run Cargo's formatter and confirm a second Cargo formatter check is clean.
-2. Run `nix fmt` in fail-on-change mode and confirm it makes no Rust changes.
-3. Re-run Cargo's formatter check to prove the two entry points converge.
-4. Run the repository's Rust checks, tests, clippy, and Nix flake checks.
-5. Review the final diff for changes outside the approved scope.
+1. Run `nix fmt` in fail-on-change mode and confirm it makes no Rust changes.
+1. Re-run Cargo's formatter check to prove the two entry points converge.
+1. Run the repository's Rust checks, tests, clippy, and Nix flake checks.
+1. Review the final diff for changes outside the approved scope.
 
 ## Alternatives Considered
 

--- a/docs/superpowers/specs/2026-07-14-rust-2024-formatting-design.md
+++ b/docs/superpowers/specs/2026-07-14-rust-2024-formatting-design.md
@@ -1,0 +1,36 @@
+# Rust 2024 Formatting Alignment
+
+## Context
+
+`cargo fmt` and `nix fmt` currently produce opposing changes in 17 Rust source files. Both commands use rustfmt 1.9.0, but Cargo passes the crate edition declared in `Cargo.toml` (`2021`) while treefmt-nix defaults its rustfmt integration to edition `2024`. Rustfmt's edition-sensitive import ordering makes the two commands alternate between valid but different layouts.
+
+## Decision
+
+Migrate the crate to Rust edition 2024 and make `Cargo.toml` the single source of truth for the edition used by treefmt.
+
+`Cargo.toml` will declare edition `2024`. `treefmt.nix` will parse `Cargo.toml` with Nix's built-in TOML parser and assign the package edition to `programs.rustfmt.edition`. This removes the hidden dependency on treefmt-nix's default and prevents the two formatter entry points from drifting during a future edition migration.
+
+## Migration
+
+Run Cargo's edition migration before changing the manifest so compiler-provided compatibility rewrites are applied while the crate is still on edition 2021. Then update the manifest to edition 2024, connect treefmt to the manifest edition, and apply the canonical Cargo formatting.
+
+The migration stays limited to compiler-required edition changes, formatter output, and the two edition configuration points. It will not include unrelated refactoring.
+
+## Failure Handling
+
+If `cargo fix --edition` reports code that cannot be migrated automatically, handle only the reported incompatibilities and preserve existing behavior. If the manifest edition cannot be read by Nix, flake evaluation should fail immediately rather than silently falling back to a potentially different formatter edition.
+
+## Verification
+
+This configuration/toolchain migration does not add a unit test. Its regression proof is formatter convergence and the existing behavioral suite:
+
+1. Run Cargo's formatter and confirm a second Cargo formatter check is clean.
+2. Run `nix fmt` in fail-on-change mode and confirm it makes no Rust changes.
+3. Re-run Cargo's formatter check to prove the two entry points converge.
+4. Run the repository's Rust checks, tests, clippy, and Nix flake checks.
+5. Review the final diff for changes outside the approved scope.
+
+## Alternatives Considered
+
+- Hardcode edition `2024` in both `Cargo.toml` and `treefmt.nix`. This is explicit but duplicates configuration and can drift again.
+- Change only `Cargo.toml`. This is the smallest edit, but it relies on treefmt-nix continuing to default to edition 2024 and leaves the original hidden coupling in place.

--- a/docs/superpowers/specs/2026-07-14-rust-2024-formatting-design.md
+++ b/docs/superpowers/specs/2026-07-14-rust-2024-formatting-design.md
@@ -16,6 +16,12 @@ Run Cargo's edition migration before changing the manifest so compiler-provided 
 
 The migration stays limited to compiler-required edition changes, formatter output, and the two edition configuration points. It will not include unrelated refactoring.
 
+## CI Remediation
+
+The first PR run exposed two pre-existing failures outside the formatter migration. The locked Nixpkgs 26.11 revision no longer provides `x86_64-darwin`, so the flake and pull-request Nix matrix will stop advertising and checking that system. This is a Nix-only support change: the `x86_64-apple-darwin` binary release target remains in `dist-workspace.toml`.
+
+Rust 1.97 also promotes redundant borrows in formatting arguments to Clippy errors on Windows. Remove those borrows without changing runtime behavior.
+
 ## Failure Handling
 
 If `cargo fix --edition` reports code that cannot be migrated automatically, handle only the reported incompatibilities and preserve existing behavior. If the manifest edition cannot be read by Nix, flake evaluation should fail immediately rather than silently falling back to a potentially different formatter edition.

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,6 @@
         "aarch64-darwin"
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
       ];
 
       perSystem = {

--- a/src/aws/profile.rs
+++ b/src/aws/profile.rs
@@ -31,7 +31,7 @@ impl Store {
 
         let credentials_file = if path.exists() {
             fs::read_to_string(&path)?.parse().wrap_err_with(|| {
-                format!("Failed to parse AWS credentials file {}", &path.display())
+                format!("Failed to parse AWS credentials file {}", path.display())
             })?
         } else {
             AwsCredentialsFile::default()

--- a/src/config/organization.rs
+++ b/src/config/organization.rs
@@ -202,7 +202,7 @@ impl Organization {
         client: &OktaClient,
         filter: glob::Pattern,
         role_override: Option<&String>,
-    ) -> impl Iterator<Item = (String, Credentials)> {
+    ) -> impl Iterator<Item = (String, Credentials)> + use<> {
         let futures = self.into_profiles(filter).map(|profile| async {
             (
                 profile.name.clone(),
@@ -269,7 +269,6 @@ mod tests {
 
     use super::*;
 
-    use std::env;
     use std::fs::File;
     use std::io::Write;
 
@@ -300,6 +299,13 @@ mod tests {
         write!(bad_nested_file, "Not an oktaws config").unwrap();
 
         tempdir
+    }
+
+    fn pattern_in(dir: &Path, pattern: &str) -> Pattern {
+        let path_pattern = dir.join(format!("{pattern}.toml"));
+        let pattern = path_pattern.as_os_str().to_string_lossy();
+
+        Pattern(glob::Pattern::new(&pattern).unwrap())
     }
 
     #[test]
@@ -491,9 +497,8 @@ foo = "foo"
     #[serial]
     fn finds_all_organizations() {
         let tempdir = create_mock_config_dir();
-        env::set_var("OKTAWS_HOME", tempdir.path());
 
-        let org_pattern: Pattern = "*".parse().unwrap();
+        let org_pattern = pattern_in(tempdir.path(), "*");
         let organizations = org_pattern.organizations().unwrap();
 
         assert_eq!(organizations.len(), 3);
@@ -504,13 +509,11 @@ foo = "foo"
     fn does_not_find_nested_config() {
         let tempdir = create_mock_config_dir();
 
-        env::set_var("OKTAWS_HOME", tempdir.path());
-
         let mock_dir = tempdir.path().join("mock");
         std::fs::create_dir(&mock_dir).unwrap();
         create_mock_toml(&mock_dir, "quz");
 
-        let org_pattern: Pattern = "*".parse().unwrap();
+        let org_pattern = pattern_in(tempdir.path(), "*");
         let organizations = org_pattern.organizations().unwrap();
 
         assert_eq!(organizations.len(), 3);
@@ -520,9 +523,8 @@ foo = "foo"
     #[serial]
     fn filters_into_organizations() {
         let tempdir = create_mock_config_dir();
-        env::set_var("OKTAWS_HOME", tempdir.path());
 
-        let org_pattern: Pattern = "ba*".parse().unwrap();
+        let org_pattern = pattern_in(tempdir.path(), "ba*");
         let organizations = org_pattern.organizations().unwrap();
 
         assert_eq!(organizations.len(), 2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,10 +594,10 @@ fn compute_account_default_role(
         );
     }
 
-    if let Some(default) = session_default_role {
-        if api_roles.contains(default) {
-            return Ok(Some(default.clone()));
-        }
+    if let Some(default) = session_default_role
+        && api_roles.contains(default)
+    {
+        return Ok(Some(default.clone()));
     }
 
     let selection = dialoguer::Select::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,7 +295,7 @@ async fn init(options: Init) -> Result<()> {
         "Federated profiles (will be written to {}):",
         oktaws_config_path.display()
     );
-    println!("{}", &org_toml);
+    println!("{org_toml}");
 
     let write_to_file = dialoguer::Confirm::new()
         .with_prompt(format!("Write config to {}?", oktaws_config_path.display()))

--- a/src/okta/auth.rs
+++ b/src/okta/auth.rs
@@ -200,15 +200,15 @@ impl Client {
     pub fn extra_verification_token(text: &str) -> Result<Option<String>> {
         let doc = kuchiki::parse_html().one(text.to_string());
 
-        let extra_verification = if let Ok(head) = doc.select_first("head") {
-            if let Ok(title) = head.as_node().select_first("title") {
-                let re = Regex::new(r".* - Extra Verification$")?;
-                re.is_match(&title.text_contents())
-            } else {
-                false
-            }
-        } else {
-            false
+        let extra_verification = match doc.select_first("head") {
+            Ok(head) => match head.as_node().select_first("title") {
+                Ok(title) => {
+                    let re = Regex::new(r".* - Extra Verification$")?;
+                    re.is_match(&title.text_contents())
+                }
+                _ => false,
+            },
+            _ => false,
         };
 
         if extra_verification {

--- a/src/okta/factors.rs
+++ b/src/okta/factors.rs
@@ -287,8 +287,8 @@ impl Client {
                 let url = links
                     .get("verify")
                     .and_then(|link| match link {
-                        Single(ref link) => Some(link.href.clone()),
-                        Multi(ref links) => links.first().map(|link| link.href.clone()),
+                        Single(link) => Some(link.href.clone()),
+                        Multi(links) => links.first().map(|link| link.href.clone()),
                     })
                     .ok_or_else(|| eyre!("No verify link found"))?;
 
@@ -311,8 +311,8 @@ impl Client {
                 let url = links
                     .get("verify")
                     .and_then(|link| match link {
-                        Single(ref link) => Some(link.href.clone()),
-                        Multi(ref links) => links.first().map(|link| link.href.clone()),
+                        Single(link) => Some(link.href.clone()),
+                        Multi(links) => links.first().map(|link| link.href.clone()),
                     })
                     .ok_or_else(|| eyre!("No verify link found"))?;
 
@@ -339,8 +339,8 @@ impl Client {
                 let mut url = links
                     .get("verify")
                     .and_then(|link| match link {
-                        Single(ref link) => Some(link.href.clone()),
-                        Multi(ref links) => links.first().map(|link| link.href.clone()),
+                        Single(link) => Some(link.href.clone()),
+                        Multi(links) => links.first().map(|link| link.href.clone()),
                     })
                     .ok_or_else(|| eyre!("No verify link found"))?;
 

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -16,7 +16,11 @@
       programs.alejandra.enable = true; # nix
       programs.jsonfmt.enable = true; # json
       programs.mdformat.enable = true; # markdown
-      programs.rustfmt.enable = true; # rust
+      programs.rustfmt = {
+        enable = true; # rust
+        edition =
+          (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.edition;
+      };
       programs.taplo.enable = true; # toml
       programs.xmllint.enable = true; # xml
     };


### PR DESCRIPTION
## Summary

- migrate the crate from Rust 2021 to Rust 2024
- make treefmt read the Rust edition directly from `Cargo.toml`
- apply the required Rust 2024 compatibility updates, including removing test-only global environment mutation
- drop Nix-only `x86_64-darwin` support because the locked Nixpkgs 26.11 revision no longer provides it; Intel macOS binary releases remain supported
- fix the Rust 1.97 Windows Clippy failures
- document the root cause, implementation plan, and CI support decision

## Root cause

`cargo fmt` read edition 2021 from `Cargo.toml`, while treefmt-nix defaulted rustfmt to edition 2024. Both commands invoked the same rustfmt binary, but the edition flag changed import ordering, so they repeatedly reversed each other.

The first PR runs also exposed two pre-existing failure classes: Nixpkgs 26.11 had removed `x86_64-darwin`, and Rust 1.97 rejected redundant borrows in formatting arguments on Windows.

## Verification

- `nix develop -c cargo fmt --all -- --check`
- `nix fmt -- --fail-on-change` — 0 files changed
- `nix develop -c cargo check --all-targets --all-features`
- `nix develop -c cargo test --all-targets --all-features` — 118 passed
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix flake check --all-systems --no-build --no-update-lock-file` — all remaining systems evaluated
- `nix flake check --print-build-logs --no-update-lock-file` — treefmt, Clippy, and nextest passed; 118 tests passed
- independent review of `master...HEAD` — no findings
